### PR TITLE
Fix wrong sc object used and deprecation warning in plot_umap

### DIFF
--- a/R/plot_umap.R
+++ b/R/plot_umap.R
@@ -112,6 +112,7 @@ plot_umap = function(augur, sc, mode = c('default', 'rank'), reduction = 'umap',
       as.data.frame()
     reduction = toupper(reduction)
     red_coord = sc@int_colData@listData$reducedDims[[reduction]]
+    rownames(red_coord) = colnames(sc)
   }
   colnames(red_coord)[1:2] = c('coord_x', 'coord_y')
   

--- a/R/plot_umap.R
+++ b/R/plot_umap.R
@@ -152,7 +152,7 @@ plot_umap = function(augur, sc, mode = c('default', 'rank'), reduction = 'umap',
                             color = auc, fill = cell_type)) +
     geom_point(size = 0.4, stroke = 0.0, shape = 16) +
     labs(x = xlab, y = ylab) +
-    guides(fill = FALSE,
+    guides(fill = "none",
            color = guide_colorbar(nbin = 10, raster = FALSE, ticks = FALSE,
                                   title.position = 'top', title.hjust = 0.5)) +
     geom_text_repel(data = labels,

--- a/R/plot_umap.R
+++ b/R/plot_umap.R
@@ -95,19 +95,19 @@ plot_umap = function(augur, sc, mode = c('default', 'rank'), reduction = 'umap',
       stop("install \"monocle3\" R package for Augur compatibility with ",
            "input monocle3 object", call. = FALSE)
     }
-    meta = monocle3::pData(input) %>%
+    meta = monocle3::pData(sc) %>%
       droplevels() %>%
       as.data.frame()
     reduction = toupper(reduction)
     red_coord = sc@int_colData@listData$reducedDims[[reduction]]
-  } else if ("SingleCellExperiment" %in% class(input)) {
+  } else if ("SingleCellExperiment" %in% class(sc)) {
     # confirm SingleCellExperiment is installed
     if (!requireNamespace("SingleCellExperiment", quietly = TRUE)) {
       stop("install \"SingleCellExperiment\" R package for Augur ",
            "compatibility with input SingleCellExperiment object",
            call. = FALSE)
     }
-    meta = SummarizedExperiment::colData(input) %>%
+    meta = SummarizedExperiment::colData(sc) %>%
       droplevels() %>%
       as.data.frame()
     reduction = toupper(reduction)


### PR DESCRIPTION
The PR fixed a minor bug in the `plot_umap` function where the `sc` object is wrongly named when `monocle3` or `SingleCellExperiment` class object is used. It also change the guides argument from `fill = FALSE` to `fill = "none"` to avoid the deprecation warning.

```
Warning: `guides(<scale> = FALSE)` is deprecated. Please use `guides(<scale> =
"none")` instead.
```

Edit: re 551f9e0, it adds the missing row names to `red_coord` if `sc` is a `SingleCellExperiment` object, so that the `barcode` column can be correctly created when calling the `rownames_to_column` function in:

https://github.com/neurorestore/Augur/blob/3b51e4ed004ef6351f6930c1d1b44eed48246f1e/R/plot_umap.R#L128-L134